### PR TITLE
Fixed is_active status

### DIFF
--- a/controllers/otp.controller.js
+++ b/controllers/otp.controller.js
@@ -1,4 +1,4 @@
-const { body } = require('express-validator/check');
+const { body } = require("express-validator/check");
 const makeid = require("../util/code_random");
 const UserModel = require("../models/store_admin");
 const OTP = require("../models/otp");
@@ -8,27 +8,27 @@ const africastalking = require("africastalking")({
 });
 const codeLength = 6;
 
-exports.validate = (method) => {
+exports.validate = method => {
   switch (method) {
-    case 'send': {
-      return [
-        body('phone_number').isNumeric(),
-      ]
+    case "send": {
+      return [body("phone_number").isNumeric()];
     }
-    case 'verify': {
+    case "verify": {
       return [
-        body('phone_number').isNumeric(),
-        body('verify').isNumeric().isLength({ min: codeLength, max: codeLength })
-      ]
+        /* body('phone_number').isNumeric(), */
+        body("verify")
+          .isNumeric()
+          .isLength({ min: codeLength, max: codeLength })
+      ];
     }
   }
-}
+};
 
 exports.send = async (req, res) => {
   try {
     const user = await UserModel.findOne({ identifier: req.body.phone_number });
 
-    if(!user) {
+    if (!user) {
       return res.status(404).json({
         success: false,
         message: "User not found",
@@ -52,9 +52,9 @@ exports.send = async (req, res) => {
 
     const otpSaveResult = await otp.save();
 
-    console.log("otpSaveResult", otpSaveResult)
+    console.log("otpSaveResult", otpSaveResult);
 
-    if(!otpSaveResult) {
+    if (!otpSaveResult) {
       return res.status(500).json({
         success: false,
         message: "Something went wrong.",
@@ -69,7 +69,7 @@ exports.send = async (req, res) => {
     await sms.send({
       to: [`+${req.body.phone_number}`],
       message: `Your number verification to MyCustomer is ${otpSaveResult.otp_code}`
-    })
+    });
 
     res.status(200).json({
       success: true,
@@ -78,7 +78,6 @@ exports.send = async (req, res) => {
         message: "successful"
       }
     });
-
   } catch (err) {
     res.status(500).json({
       success: false,
@@ -93,9 +92,9 @@ exports.send = async (req, res) => {
 
 exports.verify = async (req, res) => {
   try {
-    let user = await UserModel.findOne({ identifier: req.body.phone_number });
+    let user = await UserModel.findOne({ identifier: req.user.phone_number });
 
-    if(!user) {
+    if (!user) {
       return res.status(404).json({
         success: false,
         message: "User not found",
@@ -108,7 +107,7 @@ exports.verify = async (req, res) => {
 
     const otp = await OTP.findOne({ user_ref_code: user._id });
 
-    if(!otp || otp.otp_code != req.body.verify) {
+    if (!otp || otp.otp_code != req.body.verify) {
       return res.status(404).json({
         success: false,
         message: "OTP not found",

--- a/routes/otp.js
+++ b/routes/otp.js
@@ -12,6 +12,7 @@ router.post(
 );
 router.post(
   "/otp/verify",
+  auth,
   otpController.validate("verify"),
   bodyValidator,
   otpController.verify

--- a/routes/otp.js
+++ b/routes/otp.js
@@ -1,9 +1,20 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
 const bodyValidator = require("../util/body_validator");
 const otpController = require("./../controllers/otp.controller");
+const auth = require("../auth/auth");
 
-router.post('/otp/send', otpController.validate("send"), bodyValidator, otpController.send);
-router.post('/otp/verify', otpController.validate("verify"), bodyValidator, otpController.verify);
+router.post(
+  "/otp/send",
+  otpController.validate("send"),
+  bodyValidator,
+  otpController.send
+);
+router.post(
+  "/otp/verify",
+  otpController.validate("verify"),
+  bodyValidator,
+  otpController.verify
+);
 
-module.exports = router
+module.exports = router;


### PR DESCRIPTION
# Description

In /otp/send route the user is expected to provide their number but asking them to do same when passing their otp code in /otp/verify is not user friendly.
The user number should be gotten from req.user and that's what I fixed
Issue #277 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Here is the code not working
![fail_isssss](https://user-images.githubusercontent.com/52836079/86951179-11956c00-c149-11ea-91ea-c2fe70cc5172.PNG)

Here is the code working
![isssssss](https://user-images.githubusercontent.com/52836079/86951230-240fa580-c149-11ea-9613-d9675a40060e.PNG)


